### PR TITLE
fix: Correct Standard Logic App workflow definition

### DIFF
--- a/StandardLogicApp/test-workflow/workflow.json
+++ b/StandardLogicApp/test-workflow/workflow.json
@@ -1,22 +1,25 @@
 {
-    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
-    "contentVersion": "1.0.0.0",
-    "actions": {
-        "Response": {
-            "type": "Response",
-            "kind": "Http",
-            "inputs": {
-                "statusCode": 200,
-                "body": "hello!"
-            },
-            "runAfter": {}
+    "definition": {
+        "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+        "contentVersion": "1.0.0.0",
+        "actions": {
+            "Response": {
+                "type": "Response",
+                "kind": "Http",
+                "inputs": {
+                    "statusCode": 200,
+                    "body": "hello!"
+                },
+                "runAfter": {}
+            }
+        },
+        "outputs": {},
+        "triggers": {
+            "When_an_HTTP_request_is_received": {
+                "type": "Request",
+                "kind": "Http"
+            }
         }
     },
-    "outputs": {},
-    "triggers": {
-        "When_an_HTTP_request_is_received": {
-            "type": "Request",
-            "kind": "Http"
-        }
-    }
+    "kind": "Stateful"
 }


### PR DESCRIPTION
This commit fixes a runtime error in the Standard Logic App deployment. The `workflow.json` file was missing the top-level `definition` object and the `kind` property, which caused an 'Object reference not set to an instance of an object' error in the Azure Functions runtime.

The file has been corrected to include the proper structure, wrapping the workflow logic inside a `definition` object and adding `"kind": "Stateful"`.

This ensures the Logic App deploys and runs correctly.